### PR TITLE
add docker in rails5

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ rake db:setup db:seed
 
 ### Run
 
-Typical Rails start: 
+Typical Rails start:
 
 ```
 rails s
 ```
 
-Open up [localhost:3000](http://localhost:3000) in a browser. 
+Open up [localhost:3000](http://localhost:3000) in a browser.
 
 ### Reset Database
 
@@ -51,6 +51,23 @@ The site lists a whole bunch of ActiveRecord queries.
 Each query has input for a single parameter (although some queries may actually
 have more than one). A sample injection is provided. Clicking "Run!" will run
 the query shown.
+
+## Docker
+
+Alternatively, Docker can be used. Only available for Rails 5 for now.
+
+### Setup
+
+```
+cd inject-some-sql/rails5
+docker-compose build
+```
+
+### Run
+
+```
+docker-compose up
+```
 
 ## Adding/Modifying Queries
 

--- a/rails5/Dockerfile
+++ b/rails5/Dockerfile
@@ -1,0 +1,21 @@
+FROM ruby:2.7.1-slim
+
+RUN apt-get update; \
+    apt-get install -y --no-install-recommends \
+            build-essential \
+            patch \
+            sqlite3 \
+            libsqlite3-dev;
+
+WORKDIR /usr/src/app
+
+COPY Gemfile Gemfile.lock ./
+
+RUN gem install bundler -v 1.17.3; \
+    bundle install;
+
+COPY . .
+
+RUN rails db:setup db:seed
+
+CMD ["rails", "s", "-b", "0.0.0.0"]

--- a/rails5/docker-compose.yml
+++ b/rails5/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  app:
+    build: .
+    ports:
+      - '3000:3000'


### PR DESCRIPTION
Add Docker for Rails 5.

In the beginning I was trying to use alpine, however therubyracer was giving me some troubles.

My attempt:

```
FROM ruby:2.7.1-alpine

RUN apk update && apk upgrade

ENV LIBV8_VERSION 3.16.14.19
RUN apk add --update --no-cache build-base sqlite-dev nodejs libstdc++ && \
    apk add --update --no-cache --virtual build-deps build-base make python3 git bash && \
    gem install libv8 -v ${LIBV8_VERSION} && \
    gem install therubyracer && \
    apk del build-deps

WORKDIR /usr/src/app

COPY Gemfile Gemfile.lock ./

RUN gem install bundler -v 1.17.3 && \
    bundle install

COPY . .

CMD ["rails", "s", "-b", "0.0.0.0"]

```