### PR TITLE
Add Docker in apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ rake db:setup db:seed
 
 ### Run
 
-Typical Rails start: 
+Typical Rails start:
 
 ```
 rails s
 ```
 
-Open up [localhost:3000](http://localhost:3000) in a browser. 
+Open up [localhost:3000](http://localhost:3000) in a browser.
 
 ### Reset Database
 
@@ -51,6 +51,28 @@ The site lists a whole bunch of ActiveRecord queries.
 Each query has input for a single parameter (although some queries may actually
 have more than one). A sample injection is provided. Clicking "Run!" will run
 the query shown.
+
+## Docker
+
+Alternatively, Docker can be used.
+
+### Setup
+
+```
+docker-compose build
+```
+
+### Run
+
+```
+docker-compose up
+```
+
+Open up [localhost:3005](http://localhost:3005) for Rails 5 in a browser.
+
+Open up [localhost:3004](http://localhost:3004) for Rails 4 in a browser.
+
+Open up [localhost:3003](http://localhost:3003) for Rails 3 in a browser.
 
 ## Adding/Modifying Queries
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+  rails3:
+    build: rails3
+    ports:
+      - '3003:3000'
+  rails4:
+    build: rails4
+    ports:
+      - '3004:3000'
+  rails5:
+    build: rails5
+    ports:
+      - '3005:3000'

--- a/rails3/Dockerfile
+++ b/rails3/Dockerfile
@@ -1,0 +1,21 @@
+FROM ruby:2.7.1-slim
+
+RUN apt-get update; \
+    apt-get install -y --no-install-recommends \
+            build-essential \
+            patch \
+            sqlite3 \
+            libsqlite3-dev;
+
+WORKDIR /usr/src/app
+
+COPY Gemfile Gemfile.lock ./
+
+RUN gem install bundler -v 1.17.3; \
+    bundle install;
+
+COPY . .
+
+RUN rake db:setup db:seed
+
+CMD ["rails", "s", "-b", "0.0.0.0"]

--- a/rails3/Gemfile
+++ b/rails3/Gemfile
@@ -7,6 +7,8 @@ gem 'jquery-rails'
 gem 'coderay', "~> 1.0.8"
 gem 'rdiscount'
 
+gem 'bigdecimal', '~> 1.4', '>= 1.4.4'
+
 group :assets do
   gem 'sass-rails'
   gem 'coffee-rails'

--- a/rails3/Gemfile.lock
+++ b/rails3/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     arel (3.0.3)
+    bigdecimal (1.4.4)
     builder (3.0.4)
     coderay (1.0.9)
     coffee-rails (3.2.2)
@@ -129,6 +130,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bigdecimal (~> 1.4, >= 1.4.4)
   coderay (~> 1.0.8)
   coffee-rails
   jquery-rails

--- a/rails4/Dockerfile
+++ b/rails4/Dockerfile
@@ -1,0 +1,21 @@
+FROM ruby:2.7.1-slim
+
+RUN apt-get update; \
+    apt-get install -y --no-install-recommends \
+            build-essential \
+            patch \
+            sqlite3 \
+            libsqlite3-dev;
+
+WORKDIR /usr/src/app
+
+COPY Gemfile Gemfile.lock ./
+
+RUN gem install bundler -v 1.17.3; \
+    bundle install;
+
+COPY . .
+
+RUN rake db:setup db:seed
+
+CMD ["rails", "s", "-b", "0.0.0.0"]

--- a/rails4/Gemfile
+++ b/rails4/Gemfile
@@ -16,6 +16,8 @@ gem 'rdiscount'
 gem 'twitter-bootstrap-rails', '~>2.2.8'
 gem 'therubyracer', :platforms => :ruby
 
+gem 'bigdecimal', '~> 1.4', '>= 1.4.4'
+
 group :development, :test do
   gem 'byebug'
 end

--- a/rails4/Gemfile.lock
+++ b/rails4/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     arel (6.0.4)
+    bigdecimal (1.4.4)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
@@ -160,6 +161,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bigdecimal (~> 1.4, >= 1.4.4)
   byebug
   coderay (~> 1.0.8)
   coffee-rails (~> 4.1.0)

--- a/rails5/Dockerfile
+++ b/rails5/Dockerfile
@@ -1,0 +1,21 @@
+FROM ruby:2.7.1-slim
+
+RUN apt-get update; \
+    apt-get install -y --no-install-recommends \
+            build-essential \
+            patch \
+            sqlite3 \
+            libsqlite3-dev;
+
+WORKDIR /usr/src/app
+
+COPY Gemfile Gemfile.lock ./
+
+RUN gem install bundler -v 1.17.3; \
+    bundle install;
+
+COPY . .
+
+RUN rails db:setup db:seed
+
+CMD ["rails", "s", "-b", "0.0.0.0"]


### PR DESCRIPTION
#### Gem

Add bigdecimal in Rails 4 and Rails 3 because rake was working

Ruby 2.7.1

> NoMethodError: undefined method `new' for BigDecimal:Class

#### Docker

In the beginning I was trying to use alpine, however therubyracer was giving me some troubles.

My attempt:

```
FROM ruby:2.7.1-alpine

RUN apk update && apk upgrade

ENV LIBV8_VERSION 3.16.14.19
RUN apk add --update --no-cache build-base sqlite-dev nodejs libstdc++ && \
    apk add --update --no-cache --virtual build-deps build-base make python3 git bash && \
    gem install libv8 -v ${LIBV8_VERSION} && \
    gem install therubyracer && \
    apk del build-deps

WORKDIR /usr/src/app

COPY Gemfile Gemfile.lock ./

RUN gem install bundler -v 1.17.3 && \
    bundle install

COPY . .

RUN rake db:setup db:seed

CMD ["rails", "s", "-b", "0.0.0.0"]

```